### PR TITLE
(fix) Enums should also be made Corda-serializable

### DIFF
--- a/lib/codegen/fromcto/corda/cordavisitor.js
+++ b/lib/codegen/fromcto/corda/cordavisitor.js
@@ -159,6 +159,7 @@ public abstract class Resource
 
         parameters.fileWriter.writeLine(0, 'import com.fasterxml.jackson.annotation.JsonIgnoreProperties;');
         parameters.fileWriter.writeLine(0, '@JsonIgnoreProperties({"$class"})');
+        parameters.fileWriter.writeLine(0, '@CordaSerializable' );
         parameters.fileWriter.writeLine(0, 'public enum ' + enumDeclaration.getName() + ' {' );
 
         enumDeclaration.getOwnProperties().forEach((property) => {

--- a/test/codegen/fromcto/corda/cordavisitor.js
+++ b/test/codegen/fromcto/corda/cordavisitor.js
@@ -233,11 +233,12 @@ describe('CordaVisitor', function () {
             cordaVisit.visitEnumDeclaration(mockEnumDeclaration, param);
 
             mockStartClassFile.withArgs(mockEnumDeclaration, param).calledOnce.should.be.ok;
-            param.fileWriter.writeLine.callCount.should.deep.equal(4);
+            param.fileWriter.writeLine.callCount.should.deep.equal(5);
             param.fileWriter.writeLine.getCall(0).args.should.deep.equal([0, 'import com.fasterxml.jackson.annotation.JsonIgnoreProperties;']);
             param.fileWriter.writeLine.getCall(1).args.should.deep.equal([0, '@JsonIgnoreProperties({"$class"})']);
-            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([0, 'public enum Bob {']);
-            param.fileWriter.writeLine.getCall(3).args.should.deep.equal([0, '}']);
+            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([0, '@CordaSerializable']);
+            param.fileWriter.writeLine.getCall(3).args.should.deep.equal([0, 'public enum Bob {']);
+            param.fileWriter.writeLine.getCall(4).args.should.deep.equal([0, '}']);
             mockEndClassFile.withArgs(mockEnumDeclaration, param).calledOnce.should.be.ok;
         });
     });


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

<!--- Provide a general summary of the pull request in the Title above -->

## Issue/User story
Enum definitions should also be made serializable in the Corda format.

## Automated Tests
Corda tests have been updated accordingly.
